### PR TITLE
faster CBD = faster KEMs

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,9 +98,9 @@ The above example would also work with `ML_KEM192` and `ML_KEM256`.
 
 |  Params    |  keygen  |  keygen/s  |  encap  |  encap/s  |  decap  |  decap/s |
 |------------|---------:|-----------:|--------:|----------:|--------:|---------:|
-|ML_KEM128    |    4.91ms|      203.76|   7.69ms|     130.08|   12.11ms|    82.56 |
-|ML_KEM192    |    6.93ms|      144.31|  10.89ms|      91.86|   17.10ms|    58.47 |
-|ML_KEM256   |    9.85ms |      101.54|  14.71ms|      67.97|   22.96ms|    43.56 |
+|ML_KEM128    |    3.87ms|      258.47|   6.59ms|     151.79|  10.97ms|    91.15 |
+|ML_KEM192    |    5.85ms|      170.84|   9.67ms|     103.43|  15.83ms|    63.15 |
+|ML_KEM256   |    8.52ms|       117.38|  13.31ms|      75.12|  21.58ms|    46.34 |
 
 All times recorded using a Intel Core i7-9750H CPU and averaged over 1000 runs.
 
@@ -140,9 +140,9 @@ currently only support $q = 3329$ and $n = 256$.
 
 |  Params    |  keygen  |  keygen/s  |  encap  |  encap/s  |  decap  |  decap/s |
 |------------|---------:|-----------:|--------:|----------:|--------:|---------:|
-|Kyber512    |    4.82ms|      207.59|   7.10ms|     140.80|  11.65ms|    85.82 |
-|Kyber768    |    6.87ms|      145.60|  10.11ms|      98.92|  16.51ms|    60.58 |
-|Kyber1024   |    9.72ms|      102.91|  13.71ms|      72.94|  22.20ms|    45.05 |
+|Kyber512    |    3.97ms|     252.17|    6.11ms|     163.70|  10.55ms|     94.80 |
+|Kyber768    |    5.94ms|      168.49|   8.88ms|     112.64|  15.10ms|    66.21 |
+|Kyber1024   |    8.52ms|      117.30|  12.17ms|      82.14|  20.48ms|    48.83 |
 
 All times recorded using a Intel Core i7-9750H CPU and averaged over 1000 runs.
 

--- a/polynomials/polynomials.py
+++ b/polynomials/polynomials.py
@@ -65,8 +65,8 @@ class PolynomialRingKyber(PolynomialRing):
         coefficients = [0 for _ in range(256)]
         list_of_bits = bytes_to_bits(input_bytes)
         for i in range(256):
-            a = sum(list_of_bits[2 * i * eta + j] for j in range(eta))
-            b = sum(list_of_bits[2 * i * eta + eta + j] for j in range(eta))
+            a = sum(list_of_bits[eta * 2 * i : eta * (2 * i + 1)])
+            b = sum(list_of_bits[eta * (2 * i + 1) : eta * (2 * i + 2)])
             coefficients[i] = (a - b) % 3329
         return self(coefficients, is_ntt=is_ntt)
 

--- a/utilities/utils.py
+++ b/utilities/utils.py
@@ -1,11 +1,16 @@
 def bytes_to_bits(input_bytes):
     """
-    Convert bytes to an array of bits
+    FIPS 203: Algorithm 3
 
-    Bytes are converted little endianness following the paper
+    Convert bytes to an array of bits. Bytes are converted little endianness
+    following the paper
     """
-    bit_string = "".join(format(byte, "08b")[::-1] for byte in input_bytes)
-    return list(map(int, list(bit_string)))
+    b = [0 for _ in range(8 * len(input_bytes))]
+    for i, byte in enumerate(input_bytes):
+        for j in range(8):
+            b[8 * i + j] = byte % 2
+            byte //= 2
+    return b
 
 
 def bitstring_to_bytes(s):


### PR DESCRIPTION
In response to #44 we improve (slightly) both the `bytes_to_bits()` method and the `PolynomialRingKyber.cbd()` methods.

This results in an approximate 10-25% speed up across methods (best improvement for keygen and smallest improvement for decaps)