### PR TITLE
make sure the benchmark scripts continue to work

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,60 @@ on:
   pull_request:
 
 jobs:
+  benchmark-kyber:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 10
+      - name: Verify git status
+        run: |
+          git status
+          git remote -v
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Display Python version
+        run: python -c "import sys; print(sys.version)"
+      - name: Display installed python package versions
+        run: |
+          pip list || :
+      - name: Install build dependencies
+        run: |
+          pip install -r requirements.txt
+      - name: Display installed python package versions
+        run: |
+          pip list || :
+      - name: Run kyber benchmark
+        run: PYTHONPATH=src python benchmarks/benchmark_kyber.py
+  benchmark-ml-kem:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 10
+      - name: Verify git status
+        run: |
+          git status
+          git remote -v
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Display Python version
+        run: python -c "import sys; print(sys.version)"
+      - name: Display installed python package versions
+        run: |
+          pip list || :
+      - name: Install build dependencies
+        run: |
+          pip install -r requirements.txt
+      - name: Display installed python package versions
+        run: |
+          pip list || :
+      - name: Run ML-KEM benchmark
+        run: PYTHONPATH=src python benchmarks/benchmark_ml_kem.py
   docs-check:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
When we change API I keep on forgetting about the benchmark scripts, include them in CI to make sure they continue to work