### PR TITLE
Allow publishing to pypi when tags are pushed

### DIFF
--- a/.github/workflows/release-pypi.yml
+++ b/.github/workflows/release-pypi.yml
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: pypi
-      url: https://pypi.org/p/kyber-py
+      url: https://pypi.org/project/kyber-py/${{ github.ref_name }}
     permissions:
       id-token: write  # IMPORTANT: mandatory for trusted publishing
 
@@ -77,7 +77,7 @@ jobs:
           ./dist/*.whl
     - name: Create GitHub Release
       env:
-        GITHUB_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
+        GITHUB_TOKEN: ${{ github.token }}
       run: >-
         gh release create
         "$GITHUB_REF_NAME"

--- a/.github/workflows/release-pypi.yml
+++ b/.github/workflows/release-pypi.yml
@@ -32,7 +32,7 @@ jobs:
   publish-to-pypi:
     name: >-
       Publish Python distribution to PyPI
-    if: startsWith(github.ref, 'refs/tags/')  # only publish to PyPI on tag pushes
+    if: github.ref_type == 'tag'  # only publish to PyPI on tag pushes
     needs:
     - build
     runs-on: ubuntu-latest

--- a/.github/workflows/release-pypi.yml
+++ b/.github/workflows/release-pypi.yml
@@ -85,7 +85,7 @@ jobs:
         --notes ""
     - name: Upload artifact and their signatures to GitHub Release
       env:
-        GITHUB_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
+        GITHUB_TOKEN: ${{ github.token }}
       # Upload to GitHub Release using the `gh` CLI.
       # `dist/` contains the built packages, and the
       # sigstore-produced signatures and certificates.

--- a/.github/workflows/release-pypi.yml
+++ b/.github/workflows/release-pypi.yml
@@ -1,0 +1,95 @@
+name: publish kyber-py to pypi
+
+on: push
+
+jobs:
+  build:
+    name: Build distribution
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        persist-credentials: false
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.x"
+    - name: Install pypa/build
+      run: >-
+        python3 -m
+        pip install
+        build
+        --user
+    - name: Build a binary wheel and a source tarball
+      run: python3 -m build
+    - name: Store the distribution packages
+      uses: actions/upload-artifact@v4
+      with:
+        name: python-package-distributions
+        path: dist/
+
+  publish-to-pypi:
+    name: >-
+      Publish Python distribution to PyPI
+    if: startsWith(github.ref, 'refs/tags/')  # only publish to PyPI on tag pushes
+    needs:
+    - build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/kyber-py
+    permissions:
+      id-token: write  # IMPORTANT: mandatory for trusted publishing
+
+    steps:
+    - name: Download all the dists
+      uses: actions/download-artifact@v4
+      with:
+        name: python-package-distributions
+        path: dist/
+    - name: Publish distribution to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+
+  github-release:
+    name: >-
+      Sign the Python distribution with Sigstore
+      and upload them to GitHub Release
+    needs:
+    - publish-to-pypi
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write  # IMPORTANT: mandatory for making GitHub Releases
+      id-token: write  # IMPORTANT: mandatory for sigstore
+
+    steps:
+    - name: Download all the dists
+      uses: actions/download-artifact@v4
+      with:
+        name: python-package-distributions
+        path: dist/
+    - name: Sign the dists with Sigstore
+      uses: sigstore/gh-action-sigstore-python@v3.0.0
+      with:
+        inputs: >-
+          ./dist/*.tar.gz
+          ./dist/*.whl
+    - name: Create GitHub Release
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+      run: >-
+        gh release create
+        "$GITHUB_REF_NAME"
+        --repo "$GITHUB_REPOSITORY"
+        --notes ""
+    - name: Upload artifact signatures to GitHub Release
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+      # Upload to GitHub Release using the `gh` CLI.
+      # `dist/` contains the built packages, and the
+      # sigstore-produced signatures and certificates.
+      run: >-
+        gh release upload
+        "$GITHUB_REF_NAME" dist/**
+        --repo "$GITHUB_REPOSITORY"

--- a/.github/workflows/release-pypi.yml
+++ b/.github/workflows/release-pypi.yml
@@ -77,7 +77,7 @@ jobs:
           ./dist/*.whl
     - name: Create GitHub Release
       env:
-        GITHUB_TOKEN: ${{ github.token }}
+        GITHUB_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
       run: >-
         gh release create
         "$GITHUB_REF_NAME"
@@ -85,7 +85,7 @@ jobs:
         --notes ""
     - name: Upload artifact signatures to GitHub Release
       env:
-        GITHUB_TOKEN: ${{ github.token }}
+        GITHUB_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
       # Upload to GitHub Release using the `gh` CLI.
       # `dist/` contains the built packages, and the
       # sigstore-produced signatures and certificates.

--- a/.github/workflows/release-pypi.yml
+++ b/.github/workflows/release-pypi.yml
@@ -83,7 +83,7 @@ jobs:
         "$GITHUB_REF_NAME"
         --repo "$GITHUB_REPOSITORY"
         --notes ""
-    - name: Upload artifact signatures to GitHub Release
+    - name: Upload artifact and their signatures to GitHub Release
       env:
         GITHUB_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
       # Upload to GitHub Release using the `gh` CLI.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kyber-py"
-version = "1.0.1"
+version = "1.0.1.dev0"
 requires-python = ">= 3.9"
 description = "A pure python implementation of ML-KEM (FIPS 203)"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,25 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "kyber-py"
+version = "0.1.0"
+requires-python = ">=3.9"
+description = "A pure python implementation of ML-KEM (FIPS 203)"
+readme = "README.md"
+classifiers = [
+    "Topic :: Security :: Cryptography",
+    "Programming Language :: Python :: 3",
+    "License :: OSI Approved :: MIT License",
+]
+license = "MIT"
+license-files = ["LICEN[CS]E*"]
+
+[project.urls]
+Homepage = "https://github.com/GiacomoPope/kyber-py"
+Issues = "https://github.com/GiacomoPope/kyber-py/issues"
+
 [tool.black]
 line-length = 79
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kyber-py"
-version = "1.0.0"
+version = "1.0.1"
 requires-python = ">=3.9"
 description = "A pure python implementation of ML-KEM (FIPS 203)"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,16 +5,14 @@ build-backend = "hatchling.build"
 [project]
 name = "kyber-py"
 version = "1.0.1"
-requires-python = ">=3.9"
+requires-python = ">= 3.9"
 description = "A pure python implementation of ML-KEM (FIPS 203)"
 readme = "README.md"
 classifiers = [
     "Topic :: Security :: Cryptography",
     "Programming Language :: Python :: 3",
-    "License :: OSI Approved :: MIT License",
 ]
 license = "MIT"
-license-files = ["LICEN[CS]E*"]
 
 [project.urls]
 Homepage = "https://github.com/GiacomoPope/kyber-py"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kyber-py"
-version = "0.1.0"
+version = "1.0.0"
 requires-python = ">=3.9"
 description = "A pure python implementation of ML-KEM (FIPS 203)"
 readme = "README.md"


### PR DESCRIPTION
So the goal of this PR is to get the project ready so that new tags push the project to pypi too.

Maybe I need to do more for this to work, and the CI seems to be failing for something adjacent?

**Edit**: failure is because https://coveralls.io is down right now.