### PR TITLE
include .pyc files into ignored ones for git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 __pycache__
 docs/build
 .coverage
+*.pyc


### PR DESCRIPTION
When using the code directly from checkout the .pyc files are created in source, and that messes up the list of modified files... let's ignore them