### PR TITLE
Kyber_py CCAPKE_Keygen function correction

### DIFF
--- a/src/kyber_py/kyber/kyber.py
+++ b/src/kyber_py/kyber/kyber.py
@@ -168,7 +168,7 @@ class Kyber:
         s_hat = s.to_ntt()
 
         # Generate the error vector e ∈ R^k
-        e, N = self._generate_error_vector(sigma, self.eta_1, N)
+        e, N = self._generate_error_vector(sigma, self.eta_2, N)
         e_hat = e.to_ntt()
 
         # Construct the public key


### PR DESCRIPTION
To generate e, the correct is to use eta_2. Only change functionality of Kyber_512